### PR TITLE
get en name from desc.url

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -31,6 +31,7 @@ export async function listProblems(): Promise<IProblem[]> {
                     locked: match[2].trim().length > 0,
                     state: parseProblemState(match[3]),
                     name: match[5].trim(),
+                    name_en: "",
                     difficulty: match[6].trim(),
                     passRate: match[7].trim(),
                     companies: companies[id] || ["Unknown"],

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -234,6 +234,8 @@ async function resolveRelativePath(relativePath: string, node: IProblem, selecte
                 return node.id;
             case "name":
                 return node.name;
+            case "name_en":
+                return node.name_en;
             case "camelcasename":
                 return _.camelCase(node.name);
             case "pascalcasename":

--- a/src/explorer/LeetCodeNode.ts
+++ b/src/explorer/LeetCodeNode.ts
@@ -14,6 +14,12 @@ export class LeetCodeNode {
     public get name(): string {
         return this.data.name;
     }
+    public get name_en(): string {
+        return this.data.name_en;
+    }
+    public set name_en(name_en: string) {
+        this.data.name_en = name_en;
+    }
 
     public get state(): ProblemState {
         return this.data.state;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -76,6 +76,7 @@ export interface IProblem {
     state: ProblemState;
     id: string;
     name: string;
+    name_en: string;
     difficulty: string;
     passRate: string;
     companies: string[];
@@ -88,6 +89,7 @@ export const defaultProblem: IProblem = {
     state: ProblemState.Unknown,
     id: "",
     name: "",
+    name_en: "",
     difficulty: "",
     passRate: "",
     companies: [] as string[],

--- a/src/webview/leetCodePreviewProvider.ts
+++ b/src/webview/leetCodePreviewProvider.ts
@@ -162,6 +162,7 @@ class LeetCodePreviewProvider extends LeetCodeWebview {
             /* testcase */, ,
             ...body
         ] = descString.split("\n");
+        problem.name_en = url.substring(url.indexOf("problems") + 9, url.indexOf("description") - 1).replace("/", "_");
         return {
             title: problem.name,
             url,


### PR DESCRIPTION
One might want to view the desc in Chinese. But the file name in Chinese which auto generated will cause problems when compile/debug on Windows with g++/gdb of Cygwin or MinGW.
It can be solved like this:
``` json
"leetcode.filePath": {
  "cpp": {
    "folder": "",
    "filename": "${id}.${ext}"
  }
}
```
But maybe it's better to add an en option.
``` json
"leetcode.filePath": {
  "cpp": {
    "folder": "",
    "filename": "${id}.${name_en}.${ext}"
  }
}
```
The name_en is parsed from desc url. There might be some better source.