### PR TITLE
Add support for sorting problems by acceptance rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Thanks for [@yihong0618](https://github.com/yihong0618) provided a workaround wh
 | `leetcode.showCommentDescription` | Specify whether to include the problem description in the comments                                                                                                                                                                                            | `false`            |
 | `leetcode.useEndpointTranslation` | Use endpoint's translation (if available)                                                                                                                                                                                                                     | `true`             |
 | `leetcode.colorizeProblems`       | Add difficulty badge and colorize problems files in explorer tree                                                                                                                                                                                             | `true`             |
+| `leetcode.problems.sortStrategy`  | Specify sorting strategy for problems list                                                                                                                                                                                                                    | `None`             |
 
 ## Want Help?
 

--- a/package.json
+++ b/package.json
@@ -690,7 +690,7 @@
                         "scope": "application",
                         "description": "Add difficulty badge and colorize problems files in explorer tree."
                     },
-                    "leetcode.problems.sort-strategy": {
+                    "leetcode.problems.sortStrategy": {
                         "type": "string",
                         "default": "None",
                         "scope": "application",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "onCommand:leetcode.testSolution",
         "onCommand:leetcode.submitSolution",
         "onCommand:leetcode.switchDefaultLanguage",
+        "onCommand:leetcode.problems.sort",
         "onView:leetCodeExplorer"
     ],
     "main": "./out/src/extension",
@@ -134,6 +135,12 @@
                 "command": "leetcode.switchDefaultLanguage",
                 "title": "Switch Default Language",
                 "category": "LeetCode"
+            },
+            {
+                "command": "leetcode.problems.sort",
+                "title": "Sort Problems",
+                "category": "LeetCode",
+                "icon": "$(sort-precedence)"
             }
         ],
         "viewsContainers": {
@@ -179,6 +186,11 @@
                     "command": "leetcode.pickOne",
                     "when": "view == leetCodeExplorer",
                     "group": "overflow@0"
+                },
+                {
+                    "command": "leetcode.problems.sort",
+                    "when": "view == leetCodeExplorer",
+                    "group": "overflow@1"
                 }
             ],
             "view/item/context": [
@@ -677,6 +689,17 @@
                         "default": true,
                         "scope": "application",
                         "description": "Add difficulty badge and colorize problems files in explorer tree."
+                    },
+                    "leetcode.problems.sort-strategy": {
+                        "type": "string",
+                        "default": "None",
+                        "scope": "application",
+                        "enum": [
+                            "None",
+                            "Acceptance Rate (Ascending)",
+                            "Acceptance Rate (Descending)"
+                        ],
+                        "description": "Sorting strategy for problems list."
                     }
                 }
             }

--- a/src/commands/plugin.ts
+++ b/src/commands/plugin.ts
@@ -78,12 +78,11 @@ export async function switchSortingStrategy(): Promise<void> {
     }
 
     const leetCodeConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("leetcode");
-    await leetCodeConfig.update("problems.sort-strategy", choice.value, true);
+    await leetCodeConfig.update("problems.sortStrategy", choice.value, true);
     await leetCodeTreeDataProvider.refresh();
-    vscode.window.showInformationMessage(`Switched the sorting strategy to ${choice.value}`);
 }
 
 export function getSortingStrategy(): SortingStrategy {
     const leetCodeConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("leetcode");
-    return leetCodeConfig.get<SortingStrategy>("problems.sort-strategy", SortingStrategy.None);
+    return leetCodeConfig.get<SortingStrategy>("problems.sortStrategy", SortingStrategy.None);
 }

--- a/src/commands/plugin.ts
+++ b/src/commands/plugin.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
+import { leetCodeTreeDataProvider } from "../explorer/LeetCodeTreeDataProvider";
 import { leetCodeExecutor } from "../leetCodeExecutor";
 import { IQuickItemEx } from "../shared";
-import { Endpoint } from "../shared";
+import { Endpoint, SortingStrategy } from "../shared";
 import { DialogType, promptForOpenOutputChannel, promptForSignIn } from "../utils/uiUtils";
 import { deleteCache } from "./cache";
 
@@ -51,4 +52,38 @@ export async function switchEndpoint(): Promise<void> {
 export function getLeetCodeEndpoint(): string {
     const leetCodeConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("leetcode");
     return leetCodeConfig.get<string>("endpoint", Endpoint.LeetCode);
+}
+
+const SORT_ORDER: SortingStrategy[] = [
+    SortingStrategy.None,
+    SortingStrategy.AcceptanceRateAsc,
+    SortingStrategy.AcceptanceRateDesc,
+];
+
+export async function switchSortingStrategy(): Promise<void> {
+    const currentStrategy: SortingStrategy = getSortingStrategy();
+    const picks: Array<IQuickItemEx<string>> = [];
+    picks.push(
+        ...SORT_ORDER.map((s: SortingStrategy) => {
+            return {
+                label: `${currentStrategy === s ? "$(check)" : "    "} ${s}`,
+                value: s,
+            };
+        }),
+    );
+
+    const choice: IQuickItemEx<string> | undefined = await vscode.window.showQuickPick(picks);
+    if (!choice || choice.value === currentStrategy) {
+        return;
+    }
+
+    const leetCodeConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("leetcode");
+    await leetCodeConfig.update("problems.sort-strategy", choice.value, true);
+    await leetCodeTreeDataProvider.refresh();
+    vscode.window.showInformationMessage(`Switched the sorting strategy to ${choice.value}`);
+}
+
+export function getSortingStrategy(): SortingStrategy {
+    const leetCodeConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("leetcode");
+    return leetCodeConfig.get<SortingStrategy>("problems.sort-strategy", SortingStrategy.None);
 }

--- a/src/explorer/LeetCodeNode.ts
+++ b/src/explorer/LeetCodeNode.ts
@@ -55,6 +55,10 @@ export class LeetCodeNode {
         };
     }
 
+    public get acceptanceRate(): number {
+        return Number(this.passRate.slice(0, -1).trim());
+    }
+
     public get uri(): Uri {
         return Uri.from({
             scheme: "leetcode",

--- a/src/explorer/explorerNodeManager.ts
+++ b/src/explorer/explorerNodeManager.ts
@@ -4,7 +4,8 @@
 import * as _ from "lodash";
 import { Disposable } from "vscode";
 import * as list from "../commands/list";
-import { Category, defaultProblem, ProblemState } from "../shared";
+import { getSortingStrategy } from "../commands/plugin";
+import { Category, defaultProblem, ProblemState, SortingStrategy } from "../shared";
 import { shouldHideSolvedProblem } from "../utils/settingUtils";
 import { LeetCodeNode } from "./LeetCodeNode";
 
@@ -56,7 +57,9 @@ class ExplorerNodeManager implements Disposable {
     }
 
     public getAllNodes(): LeetCodeNode[] {
-        return Array.from(this.explorerNodeMap.values());
+        return this.applySortingStrategy(
+            Array.from(this.explorerNodeMap.values()),
+        );
     }
 
     public getAllDifficultyNodes(): LeetCodeNode[] {
@@ -114,7 +117,7 @@ class ExplorerNodeManager implements Disposable {
                 res.push(node);
             }
         }
-        return res;
+        return this.applySortingStrategy(res);
     }
 
     public getChildrenNodesById(id: string): LeetCodeNode[] {
@@ -142,7 +145,7 @@ class ExplorerNodeManager implements Disposable {
                     break;
             }
         }
-        return res;
+        return this.applySortingStrategy(res);
     }
 
     public dispose(): void {
@@ -184,6 +187,15 @@ class ExplorerNodeManager implements Disposable {
                 break;
             default:
                 break;
+        }
+    }
+
+    private applySortingStrategy(nodes: LeetCodeNode[]): LeetCodeNode[] {
+        const strategy: SortingStrategy = getSortingStrategy();
+        switch (strategy) {
+            case SortingStrategy.AcceptanceRateAsc: return nodes.sort((x: LeetCodeNode, y: LeetCodeNode) => Number(x.acceptanceRate) - Number(y.acceptanceRate));
+            case SortingStrategy.AcceptanceRateDesc: return nodes.sort((x: LeetCodeNode, y: LeetCodeNode) => Number(y.acceptanceRate) - Number(x.acceptanceRate));
+            default: return nodes;
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             vscode.commands.registerCommand("leetcode.switchDefaultLanguage", () => switchDefaultLanguage()),
             vscode.commands.registerCommand("leetcode.addFavorite", (node: LeetCodeNode) => star.addFavorite(node)),
             vscode.commands.registerCommand("leetcode.removeFavorite", (node: LeetCodeNode) => star.removeFavorite(node)),
+            vscode.commands.registerCommand("leetcode.problems.sort", () => plugin.switchSortingStrategy()),
         );
 
         await leetCodeExecutor.switchEndpoint(plugin.getLeetCodeEndpoint());

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -116,3 +116,11 @@ export enum DescriptionConfiguration {
 }
 
 export const leetcodeHasInited: string = "leetcode.hasInited";
+
+export enum SortingStrategy {
+    None = "None",
+    AcceptanceRateAsc = "Acceptance Rate (Ascending)",
+    AcceptanceRateDesc = "Acceptance Rate (Descending)",
+    FrequencyAsc = "Frequency (Ascending)",
+    FrequencyDesc = "Frequency (Descending)",
+}


### PR DESCRIPTION
Added basic sorting strategies to sort problems based on acceptance rate. This can be extended to sort on frequency (if supported by leetcode-cli).

**Menu**
<img width="1492" alt="Menu" src="https://user-images.githubusercontent.com/8014603/130200439-267d1309-0908-409a-ba47-295e4f6b15b0.png">

**Sorting Options**
<img width="1489" alt="Sorting Options" src="https://user-images.githubusercontent.com/8014603/130200457-bd2f68af-85cc-401c-a5c4-c767dc9351d2.png">
