### PR TITLE
feat: remove scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LeetCode
 
+## remove "scope": "application",
+
 > Solve LeetCode problems in VS Code
 
 <p align="center">
@@ -20,7 +22,7 @@
   </a>
 </p>
 
-- English Document | [中文文档](https://github.com/LeetCode-OpenSource/vscode-leetcode/blob/master/docs/README_zh-CN.md)
+-   English Document | [中文文档](https://github.com/LeetCode-OpenSource/vscode-leetcode/blob/master/docs/README_zh-CN.md)
 
 ## ❗️ Attention ❗️- Workaround to login to LeetCode endpoint
 
@@ -34,9 +36,9 @@ Thanks for [@yihong0618](https://github.com/yihong0618) provided a workaround wh
 
 ## Requirements
 
-- [VS Code 1.30.1+](https://code.visualstudio.com/)
-- [Node.js 10+](https://nodejs.org)
-  > NOTE: Please make sure that `Node` is in your `PATH` environment variable. You can also use the setting `leetcode.nodePath` to specify the location of your `Node.js` executable.
+-   [VS Code 1.30.1+](https://code.visualstudio.com/)
+-   [Node.js 10+](https://nodejs.org)
+    > NOTE: Please make sure that `Node` is in your `PATH` environment variable. You can also use the setting `leetcode.nodePath` to specify the location of your `Node.js` executable.
 
 ## Quick Start
 
@@ -50,11 +52,11 @@ Thanks for [@yihong0618](https://github.com/yihong0618) provided a workaround wh
   <img src="https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/sign_in.png" alt="Sign in" />
 </p>
 
-- Simply click `Sign in to LeetCode` in the `LeetCode Explorer` will let you **sign in** with your LeetCode account.
+-   Simply click `Sign in to LeetCode` in the `LeetCode Explorer` will let you **sign in** with your LeetCode account.
 
-- You can also use the following command to sign in/out:
-  - **LeetCode: Sign in**
-  - **LeetCode: Sign out**
+-   You can also use the following command to sign in/out:
+    -   **LeetCode: Sign in**
+    -   **LeetCode: Sign out**
 
 ---
 
@@ -64,14 +66,14 @@ Thanks for [@yihong0618](https://github.com/yihong0618) provided a workaround wh
   <img src="https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/endpoint.png" alt="Switch Endpoint" />
 </p>
 
-- By clicking the button ![btn_endpoint](https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/btn_endpoint.png) at the **explorer's navigation bar**, you can switch between different endpoints.
+-   By clicking the button ![btn_endpoint](https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/btn_endpoint.png) at the **explorer's navigation bar**, you can switch between different endpoints.
 
-- The supported endpoints are:
+-   The supported endpoints are:
 
-  - **leetcode.com**
-  - **leetcode.cn**
+    -   **leetcode.com**
+    -   **leetcode.cn**
 
-  > Note: The accounts of different endpoints are **not** shared. Please make sure you are using the right endpoint. The extension will use `leetcode.com` by default.
+    > Note: The accounts of different endpoints are **not** shared. Please make sure you are using the right endpoint. The extension will use `leetcode.com` by default.
 
 ---
 
@@ -81,14 +83,14 @@ Thanks for [@yihong0618](https://github.com/yihong0618) provided a workaround wh
   <img src="https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/pick_problem.png" alt="Pick a Problem" />
 </p>
 
-- Directly click on the problem or right click the problem in the `LeetCode Explorer` and select `Preview Problem` to see the problem description.
-- Select `Show Problem` to directly open the file with the problem description.
+-   Directly click on the problem or right click the problem in the `LeetCode Explorer` and select `Preview Problem` to see the problem description.
+-   Select `Show Problem` to directly open the file with the problem description.
 
-  > Note：You can specify the path of the workspace folder to store the problem files by updating the setting `leetcode.workspaceFolder`. The default value is：**$HOME/.leetcode/**.
+    > Note：You can specify the path of the workspace folder to store the problem files by updating the setting `leetcode.workspaceFolder`. The default value is：**$HOME/.leetcode/**.
 
-  > You can specify whether including the problem description in comments or not by updating the setting `leetcode.showCommentDescription`.
+    > You can specify whether including the problem description in comments or not by updating the setting `leetcode.showCommentDescription`.
 
-  > You can switch the default language by triggering the command: `LeetCode: Switch Default Language`.
+    > You can switch the default language by triggering the command: `LeetCode: Switch Default Language`.
 
 ---
 
@@ -98,15 +100,15 @@ Thanks for [@yihong0618](https://github.com/yihong0618) provided a workaround wh
   <img src="https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/shortcuts.png" alt="Editor Shortcuts" />
 </p>
 
-- The extension supports 5 editor shortcuts (aka Code Lens):
+-   The extension supports 5 editor shortcuts (aka Code Lens):
 
-  - `Submit`: Submit your answer to LeetCode.
-  - `Test`: Test your answer with customized test cases.
-  - `Star/Unstar`: Star or unstar the current problem.
-  - `Solution`: Show the top voted solution for the current problem.
-  - `Description`: Show the problem description page.
+    -   `Submit`: Submit your answer to LeetCode.
+    -   `Test`: Test your answer with customized test cases.
+    -   `Star/Unstar`: Star or unstar the current problem.
+    -   `Solution`: Show the top voted solution for the current problem.
+    -   `Description`: Show the problem description page.
 
-  > Note: You can customize the shortcuts using the setting: `leetcode.editor.shortcuts`. By default, only `Submit` and `Test` shortcuts are enabled.
+    > Note: You can customize the shortcuts using the setting: `leetcode.editor.shortcuts`. By default, only `Submit` and `Test` shortcuts are enabled.
 
 ---
 
@@ -116,7 +118,7 @@ Thanks for [@yihong0618](https://github.com/yihong0618) provided a workaround wh
   <img src="https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/search.png" alt="Search problems by Keywords" />
 </p>
 
-- By clicking the button ![btn_search](https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/btn_search.png) at the **explorer's navigation bar**, you can search the problems by keywords.
+-   By clicking the button ![btn_search](https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/btn_search.png) at the **explorer's navigation bar**, you can search the problems by keywords.
 
 ---
 
@@ -126,7 +128,7 @@ Thanks for [@yihong0618](https://github.com/yihong0618) provided a workaround wh
   <img src="https://raw.githubusercontent.com/LeetCode-OpenSource/vscode-leetcode/master/docs/imgs/session.png" alt="Manage Session" />
 </p>
 
-- To manage your LeetCode sessions, just clicking the `LeetCode: ***` at the bottom of the status bar. You can **switch** between sessions or **create**, **delete** a session.
+-   To manage your LeetCode sessions, just clicking the `LeetCode: ***` at the bottom of the status bar. You can **switch** between sessions or **create**, **delete** a session.
 
 ## Settings
 
@@ -160,5 +162,5 @@ Refer to [CHANGELOG](https://github.com/LeetCode-OpenSource/vscode-leetcode/blob
 
 ## Acknowledgement
 
-- This extension is based on [@skygragon](https://github.com/skygragon)'s [leetcode-cli](https://github.com/skygragon/leetcode-cli) open source project.
-- Special thanks to our [contributors](https://github.com/LeetCode-OpenSource/vscode-leetcode/blob/master/ACKNOWLEDGEMENTS.md).
+-   This extension is based on [@skygragon](https://github.com/skygragon)'s [leetcode-cli](https://github.com/skygragon/leetcode-cli) open source project.
+-   Special thanks to our [contributors](https://github.com/LeetCode-OpenSource/vscode-leetcode/blob/master/ACKNOWLEDGEMENTS.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "vscode-leetcode",
-    "version": "0.18.1",
+    "name": "vscode-leetcode-no-scope",
+    "version": "0.18.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "vscode-leetcode",
-            "version": "0.18.1",
+            "name": "vscode-leetcode-no-scope",
+            "version": "0.18.2",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-    "name": "vscode-leetcode",
-    "displayName": "LeetCode",
+    "name": "vscode-leetcode-no-scope",
+    "displayName": "vscode-leetcode-no-scope",
     "description": "Solve LeetCode problems in VS Code",
-    "version": "0.18.2",
+    "version": "0.19.0",
     "author": "LeetCode",
-    "publisher": "LeetCode",
+    "publisher": "baicie",
     "license": "MIT",
     "icon": "resources/LeetCode.png",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -296,7 +296,6 @@
                     "leetcode.hideSolved": {
                         "type": "boolean",
                         "default": false,
-                        "scope": "application",
                         "description": "Hide solved problems."
                     },
                     "leetcode.defaultLanguage": {
@@ -320,7 +319,6 @@
                             "swift",
                             "typescript"
                         ],
-                        "scope": "application",
                         "description": "Default language for solving the problems."
                     },
                     "leetcode.showDescription": {
@@ -336,50 +334,42 @@
                             "Show the problem description in a new webview window",
                             "Show the problem description in the file's comment"
                         ],
-                        "scope": "application",
                         "description": "Specify where to show the description."
                     },
                     "leetcode.showCommentDescription": {
                         "type": "boolean",
                         "default": false,
-                        "scope": "application",
                         "description": "[Deprecated] Include problem description in comments.",
                         "deprecationMessage": "This setting will be deprecated in 0.17.0, please use 'leetcode.showDescription' instead"
                     },
                     "leetcode.hint.setDefaultLanguage": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Show a hint to set the default language."
                     },
                     "leetcode.hint.configWebviewMarkdown": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Show a hint to change webview appearance through markdown config."
                     },
                     "leetcode.hint.commentDescription": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Show a hint to enable comment description in solution code file."
                     },
                     "leetcode.hint.commandShortcut": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Show a hint to configure commands key binding."
                     },
                     "leetcode.useWsl": {
                         "type": "boolean",
                         "default": false,
-                        "scope": "application",
                         "description": "Use the Windows Subsystem for Linux."
                     },
                     "leetcode.endpoint": {
                         "type": "string",
                         "default": "leetcode",
-                        "scope": "application",
                         "enum": [
                             "leetcode",
                             "leetcode-cn"
@@ -389,18 +379,15 @@
                     "leetcode.useEndpointTranslation": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Use endpoint's translation (if available)"
                     },
                     "leetcode.workspaceFolder": {
                         "type": "string",
-                        "scope": "application",
                         "description": "The path of the workspace folder to store the problem files.",
                         "default": ""
                     },
                     "leetcode.filePath": {
                         "type": "object",
-                        "scope": "application",
                         "description": "The output folder and filename to save the problem files.",
                         "properties": {
                             "default": {
@@ -642,7 +629,6 @@
                     "leetcode.enableStatusBar": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Show the LeetCode status bar or not."
                     },
                     "leetcode.editor.shortcuts": {
@@ -651,7 +637,6 @@
                             "submit",
                             "test"
                         ],
-                        "scope": "application",
                         "items": {
                             "type": "string",
                             "enum": [
@@ -674,25 +659,21 @@
                     "leetcode.enableSideMode": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Determine whether to group all webview pages into the second editor column when solving problems."
                     },
                     "leetcode.nodePath": {
                         "type": "string",
                         "default": "node",
-                        "scope": "application",
                         "description": "The Node.js executable path. for example, C:\\Program Files\\nodejs\\node.exe"
                     },
                     "leetcode.colorizeProblems": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Add difficulty badge and colorize problems files in explorer tree."
                     },
                     "leetcode.problems.sortStrategy": {
                         "type": "string",
                         "default": "None",
-                        "scope": "application",
                         "enum": [
                             "None",
                             "Acceptance Rate (Ascending)",
@@ -703,7 +684,6 @@
                     "leetcode.allowReportData": {
                         "type": "boolean",
                         "default": true,
-                        "scope": "application",
                         "description": "Allow LeetCode to report anonymous usage data to improve the product."
                     }
                 }


### PR DESCRIPTION
zh: 两台电脑来回改设置麻烦的很干脆把设置的scope去掉算了 这样无论是在用户设置或者工作区或者工作区setting.json都可以了
en: It is very troublesome to change the settings between two computers. Just remove the scope of the settings. In this way, it can be done in user settings, workspace or workspace setting.json.